### PR TITLE
feat: scaffold application architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
@@ -15,6 +16,7 @@
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^6.28.0",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1",
     "tailwindcss-animate": "^1.0.7"
@@ -31,6 +33,11 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.5",
+    "jsdom": "^26.1.0",
+    "vitest": "^2.0.5",
     "tailwindcss": "^3.4.14",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,16 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter } from 'react-router-dom'
+import Layout from './components/Layout'
+import { AppRoutes } from './routes'
+import { AuthProvider } from './contexts/AuthContext'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <AuthProvider>
+      <BrowserRouter>
+        <Layout>
+          <AppRoutes />
+        </Layout>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }
-
-export default App

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,0 +1,11 @@
+export async function httpClient(url: string, options: RequestInit = {}) {
+  const token = localStorage.getItem('token')
+  const headers = new Headers(options.headers)
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+
+  const response = await fetch(url, { ...options, headers })
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return response.json()
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div className="p-4">{children}</div>
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useState, ReactNode } from 'react'
+
+interface AuthContextType {
+  user: unknown
+  login: (userData: unknown) => void
+  logout: () => void
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<unknown>(null)
+
+  const login = (userData: unknown) => setUser(userData)
+  const logout = () => setUser(null)
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+export function useApi<T>(request: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  const execute = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await request()
+      setData(response)
+    } catch (err) {
+      setError(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { data, loading, error, execute }
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from '../contexts/AuthContext'
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>Dashboard</div>
+}

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>Login Page</div>
+}

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  return <>{children}</>
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,20 @@
+import { Routes, Route } from 'react-router-dom'
+import Login from '../pages/Login'
+import Dashboard from '../pages/Dashboard'
+import ProtectedRoute from './ProtectedRoute'
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+    </Routes>
+  )
+}

--- a/src/tests/example.test.tsx
+++ b/src/tests/example.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import App from '../App'
+
+describe('App', () => {
+  it('renders login page by default', () => {
+    render(<App />)
+    expect(screen.getByText(/Login Page/i)).toBeInTheDocument()
+  })
+})

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export function noop() {}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
+  "types": ["vitest/globals"],
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/tests/setup.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- set up routing with auth provider and layout
- add auth context, hooks, http client, and sample pages
- configure vitest and create example test

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c407cd10288330be2d1d75b9acc7ad