### PR TITLE
fix: configure vite alias for src

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths';
-import path from "path";
+import tsconfigPaths from 'vite-tsconfig-paths'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/tests/setup.ts',
   },
-  alias: {
-      "@": path.resolve(__dirname, "src")
-    }
 })


### PR DESCRIPTION
## Summary
- configure Vite's resolve alias for `@` to point to `src`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: Cannot find type definition file for 'aria-query', 'babel__core', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4a358df4083308720a386c6eb021a