### PR TITLE
feat: add centralized axios client

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,50 @@
+# Cliente HTTP
+
+Este diretório contém a implementação centralizada do cliente HTTP baseado em Axios.
+
+## Uso básico
+
+```ts
+import httpClient from './axios'
+
+export async function fetchUsers() {
+  return httpClient.get<{ users: unknown[] }>({ url: '/users' })
+}
+```
+
+## Definindo o token de autorização
+
+Após autenticar o usuário, defina o token para que seja incluído nas próximas requisições:
+
+```ts
+import httpClient from './axios'
+
+httpClient.setAuthToken('meu-token')
+```
+
+## Criando novas chamadas de API
+
+1. Crie um arquivo de serviço em `src/api` ou em outro diretório de serviços.
+2. Importe `httpClient`.
+3. Utilize os métodos `get`, `post`, `put`, `patch`, `delete`, `getBlob` ou `postBlob`.
+4. Cada método aceita um objeto `RequestOptions` com:
+   - `url`: caminho do endpoint (obrigatório);
+   - `data`: corpo da requisição (opcional);
+   - `params`: parâmetros de consulta (opcional);
+   - `extraHeaders`: cabeçalhos adicionais (opcional).
+
+### Exemplo
+
+```ts
+import httpClient from './axios'
+
+export async function fetchPosts(page: number) {
+  return httpClient.get<{ posts: Post[] }>({
+    url: '/posts',
+    params: { page },
+  })
+}
+```
+
+Para uploads ou downloads de arquivos, utilize os métodos `postBlob` e `getBlob` respectivamente.
+

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { api } from './axios'
+import httpClient from './axios'
 
 export interface LoginPayload {
   email: string
@@ -6,6 +6,8 @@ export interface LoginPayload {
 }
 
 export async function login(payload: LoginPayload) {
-  const { data } = await api.post('/login', payload)
-  return data
+  return httpClient.post<{ token: string }>({
+    url: '/login',
+    data: payload,
+  })
 }


### PR DESCRIPTION
## Summary
- implement singleton `AxiosClient` with request/response interceptors and consistent error handling
- provide helper methods for common HTTP verbs and blob transfers
- update auth service and documentation to use the new client

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, react-hooks/rules-of-hooks)*
- `npx vitest run --reporter=basic` *(fails: renders login page by default)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bb63b9d88330a8542716e6dd234e