### PR TITLE
Fix login hook usage

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -53,4 +53,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -7,10 +7,10 @@ import { useAuth } from "../../hooks/useAuth";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const authContext = useAuth();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const authContext = useAuth();
     authContext.login({ email, password });
   };
 

--- a/src/tests/example.test.tsx
+++ b/src/tests/example.test.tsx
@@ -4,6 +4,6 @@ import App from '../App'
 describe('App', () => {
   it('renders login page by default', () => {
     render(<App />)
-    expect(screen.getByText(/Login Page/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/Email/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- call `useAuth` at the top of the login component to obey hook rules
- remove unused `buttonVariants` export to satisfy lint
- update example test to reflect login page content

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d1b4cf5883309a815d957cf5ba7e