### PR TITLE
Add login service and global auth storage

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,8 +5,19 @@ export interface LoginPayload {
   password: string
 }
 
-export async function login(payload: LoginPayload) {
-  return httpClient.post<{ token: string }>({
+export interface User {
+  id: string
+  name: string
+  email: string
+}
+
+export interface LoginResponse {
+  token: string
+  user: User
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  return httpClient.post<LoginResponse>({
     url: '/login',
     data: payload,
   })

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,23 +1,50 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useState } from 'react'
+import { createContext, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import type { LoginPayload, User } from '../api/auth'
+import {
+  clearStoredAuth,
+  getStoredAuth,
+  login as authLogin,
+} from '../services/auth'
 
 export interface AuthContextType {
-  user: unknown
-  login: (userData: unknown) => void
+  user: User | null
+  token: string | null
+  login: (credentials: LoginPayload) => Promise<void>
   logout: () => void
 }
 
-export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+export const AuthContext = createContext<AuthContextType | undefined>(
+  undefined,
+)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<unknown>(null)
+  const [user, setUser] = useState<User | null>(null)
+  const [token, setToken] = useState<string | null>(null)
 
-  const login = (userData: unknown) => setUser(userData)
-  const logout = () => setUser(null)
+  useEffect(() => {
+    const stored = getStoredAuth()
+    if (stored) {
+      setUser(stored.user)
+      setToken(stored.token)
+    }
+  }, [])
+
+  const login = async (credentials: LoginPayload) => {
+    const data = await authLogin(credentials)
+    setUser(data.user)
+    setToken(data.token)
+  }
+
+  const logout = () => {
+    setUser(null)
+    setToken(null)
+    clearStoredAuth()
+  }
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, token, login, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -9,9 +9,9 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const authContext = useAuth();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    authContext.login({ email, password });
+    await authContext.login({ email, password });
   };
 
   return (

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,28 @@
+import httpClient from '../api/axios'
+import { login as loginApi, LoginPayload, LoginResponse } from '../api/auth'
+
+const STORAGE_KEY = 'auth'
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  const data = await loginApi(payload)
+  httpClient.setAuthToken(data.token)
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  return data
+}
+
+export function getStoredAuth(): LoginResponse | null {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    const data: LoginResponse = JSON.parse(raw)
+    httpClient.setAuthToken(data.token)
+    return data
+  } catch {
+    return null
+  }
+}
+
+export function clearStoredAuth() {
+  localStorage.removeItem(STORAGE_KEY)
+  httpClient.setAuthToken(null)
+}


### PR DESCRIPTION
## Summary
- add auth service to handle login and token persistence
- store user and token in AuthContext for global access
- call context login from Login page

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c4d39ac930833097a81a397ed1a501