### PR TITLE
refactor auth token handling for cookie-based refresh

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -12,14 +12,14 @@ export async function fetchUsers() {
 }
 ```
 
-## Definindo os tokens de autorização
+## Definindo o token de acesso
 
-Após autenticar o usuário, defina os tokens para que o token de acesso seja incluído nas próximas requisições e o token de atualização seja utilizado automaticamente:
+Após autenticar o usuário, defina o token de acesso para que ele seja incluído nas próximas requisições. A renovação do token é realizada automaticamente pelo cookie HttpOnly fornecido pelo backend:
 
 ```ts
 import httpClient from './axios'
 
-httpClient.setAuthTokens('meu-access-token', 'meu-refresh-token')
+httpClient.setAuthTokens('meu-access-token')
 ```
 
 ## Criando novas chamadas de API

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -8,12 +8,13 @@ export interface LoginPayload {
 
 export interface LoginResponse {
   accessToken: string
-  refreshToken: string
+  refreshToken?: string | null
   user: User
 }
 
-interface RefreshPayload {
-  refreshToken: string
+export interface RefreshResponse {
+  accessToken: string
+  refreshToken?: string | null
 }
 
 export async function login(payload: LoginPayload): Promise<LoginResponse> {
@@ -23,18 +24,15 @@ export async function login(payload: LoginPayload): Promise<LoginResponse> {
   })
 }
 
-export async function refreshSession(refreshToken: string): Promise<LoginResponse> {
-  const payload: RefreshPayload = { refreshToken }
-  return httpClient.post<LoginResponse>({
+export async function refreshSession(): Promise<RefreshResponse> {
+  return httpClient.post<RefreshResponse>({
     url: '/auth/auth/refresh',
-    data: payload,
   })
 }
 
-export async function logout(refreshToken: string): Promise<void> {
+export async function logout(): Promise<void> {
   return httpClient.post<void>({
     url: '/auth/logout',
-    data: { refreshToken },
   })
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,30 +1,54 @@
-import type { AuthSession } from '../types/auth'
+import type { AuthSession, User } from '../types/auth'
 
-const AUTH_STORAGE_KEY = 'memo:auth-session'
+const AUTH_USER_STORAGE_KEY = 'memo:auth-user'
 
 type AuthChangedEventDetail = AuthSession | null
+
+let inMemoryAccessToken: string | null = null
+let inMemoryUser: User | null | undefined
 
 function isBrowserEnvironment(): boolean {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 }
 
-function readSessionFromStorage(): AuthSession | null {
+function readUserFromStorage(): User | null {
   if (!isBrowserEnvironment()) {
     return null
   }
 
-  const rawValue = window.localStorage.getItem(AUTH_STORAGE_KEY)
+  const rawValue = window.localStorage.getItem(AUTH_USER_STORAGE_KEY)
   if (!rawValue) {
     return null
   }
 
   try {
-    return JSON.parse(rawValue) as AuthSession
+    return JSON.parse(rawValue) as User
   } catch (error) {
-    console.error('Failed to parse stored auth session', error)
-    window.localStorage.removeItem(AUTH_STORAGE_KEY)
+    console.error('Failed to parse stored auth user', error)
+    window.localStorage.removeItem(AUTH_USER_STORAGE_KEY)
     return null
   }
+}
+
+function persistUser(user: User | null): void {
+  if (!isBrowserEnvironment()) {
+    return
+  }
+
+  if (user) {
+    window.localStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(user))
+  } else {
+    window.localStorage.removeItem(AUTH_USER_STORAGE_KEY)
+  }
+}
+
+function getUserFromMemory(): User | null {
+  if (inMemoryUser !== undefined) {
+    return inMemoryUser
+  }
+
+  inMemoryUser = readUserFromStorage()
+  return inMemoryUser
 }
 
 function dispatchAuthChanged(session: AuthChangedEventDetail) {
@@ -35,63 +59,57 @@ function dispatchAuthChanged(session: AuthChangedEventDetail) {
   window.dispatchEvent(new CustomEvent<AuthChangedEventDetail>('auth:changed', { detail: session }))
 }
 
-function writeSessionToStorage(session: AuthSession | null) {
-  if (!isBrowserEnvironment()) {
-    return
-  }
-
-  if (session) {
-    window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session))
-  } else {
-    window.localStorage.removeItem(AUTH_STORAGE_KEY)
-  }
-
-  dispatchAuthChanged(session)
+export function loadStoredUser(): User | null {
+  return getUserFromMemory()
 }
 
 export function saveAuthSession(session: AuthSession): void {
-  writeSessionToStorage(session)
+  inMemoryAccessToken = session.accessToken
+  inMemoryUser = session.user
+  persistUser(session.user)
+  dispatchAuthChanged({ ...session })
 }
 
 export function loadAuthSession(): AuthSession | null {
-  return readSessionFromStorage()
-}
-
-export function updateAuthSession(partialSession: Partial<AuthSession>): AuthSession | null {
-  const currentSession = readSessionFromStorage()
-
-  if (!currentSession) {
-    if (!partialSession.accessToken || !partialSession.refreshToken) {
-      return null
-    }
-
-    const nextSession: AuthSession = {
-      accessToken: partialSession.accessToken,
-      refreshToken: partialSession.refreshToken,
-      user: partialSession.user ?? null,
-    }
-
-    writeSessionToStorage(nextSession)
-    return nextSession
-  }
-
-  const nextSession: AuthSession = {
-    accessToken: partialSession.accessToken ?? currentSession.accessToken,
-    refreshToken: partialSession.refreshToken ?? currentSession.refreshToken,
-    user: partialSession.user ?? currentSession.user,
-  }
-
-  if (!nextSession.accessToken || !nextSession.refreshToken) {
-    writeSessionToStorage(null)
+  if (!inMemoryAccessToken) {
     return null
   }
 
-  writeSessionToStorage(nextSession)
-  return nextSession
+  return {
+    accessToken: inMemoryAccessToken,
+    user: getUserFromMemory(),
+  }
+}
+
+export function updateAuthSession(partialSession: Partial<AuthSession>): AuthSession | null {
+  if (partialSession.accessToken !== undefined) {
+    inMemoryAccessToken = partialSession.accessToken ?? null
+  }
+
+  if (partialSession.user !== undefined) {
+    inMemoryUser = partialSession.user ?? null
+    persistUser(inMemoryUser)
+  }
+
+  if (!inMemoryAccessToken) {
+    clearAuthSession()
+    return null
+  }
+
+  const session: AuthSession = {
+    accessToken: inMemoryAccessToken,
+    user: getUserFromMemory(),
+  }
+
+  dispatchAuthChanged(session)
+  return session
 }
 
 export function clearAuthSession(): void {
-  writeSessionToStorage(null)
+  inMemoryAccessToken = null
+  inMemoryUser = null
+  persistUser(null)
+  dispatchAuthChanged(null)
 }
 
-export { AUTH_STORAGE_KEY }
+export { AUTH_USER_STORAGE_KEY }

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -3,7 +3,10 @@ import { Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 export default function ProtectedRoute({ children }: { children: ReactNode }) {
-  const { token } = useAuth()
+  const { token, isLoading } = useAuth()
+  if (isLoading) {
+    return null
+  }
   if (!token) {
     return <Navigate to="/login" replace />
   }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -29,11 +29,5 @@ export interface User {
 
 export interface AuthSession {
   accessToken: string
-  refreshToken: string
   user: User | null
-}
-
-export interface AuthTokens {
-  accessToken: string
-  refreshToken: string
 }


### PR DESCRIPTION
## Summary
- keep authentication tokens in memory while persisting only the user payload in localStorage and broadcasting session changes
- adjust the API client and auth services to rely on the backend refresh cookie, including axios withCredentials support and a restoreSession helper
- update the React auth context, protected route guard, types, and docs to reflect the new cookie-based flow

## Testing
- npm run lint
- npm run build *(fails: existing TypeScript configuration and alias resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d1ff0a448330a1da790bfb20192f