### PR TITLE
feat: submit novo projeto via modal

### DIFF
--- a/src/api/projeto.ts
+++ b/src/api/projeto.ts
@@ -1,0 +1,18 @@
+import httpClient from "./axios"
+import type { Projeto } from "@/types/auth"
+
+export interface CreateProjetoPayload {
+  nome: string
+  descricao?: string | null
+  instituicao: string
+  cargo: string
+}
+
+export type CreateProjetoResponse = Projeto
+
+export async function createProjeto(payload: CreateProjetoPayload): Promise<CreateProjetoResponse> {
+  return httpClient.post<CreateProjetoResponse>({
+    url: "/projeto",
+    data: payload,
+  })
+}

--- a/src/components/sidebar/nav-modal-adicionar-projeto.tsx
+++ b/src/components/sidebar/nav-modal-adicionar-projeto.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import { createProjeto } from "@/api/projeto"
 
 const projetoFormSchema = z.object({
   name: z
@@ -72,10 +74,26 @@ export function ModalAdicionarProjeto({ open, onOpenChange, onSubmit }: ModalAdi
     [onOpenChange, reset],
   )
 
-  const handleSubmit = submit(async (values) => {
-    await onSubmit?.(values)
-    onOpenChange(false)
-    reset()
+  const handleSubmit = submit(async values => {
+    try {
+      const descricao = values.description?.length ? values.description : null
+
+      await createProjeto({
+        nome: values.name,
+        descricao,
+        instituicao: values.instituicao,
+        cargo: values.cargo,
+      })
+
+      toast.success("Projeto criado com sucesso!")
+
+      await onSubmit?.(values)
+      onOpenChange(false)
+      reset()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Não foi possível criar o projeto."
+      toast.error(message)
+    }
   })
 
   return (


### PR DESCRIPTION
## Summary
- criar cliente de API para cadastrar novos projetos utilizando axios centralizado
- integrar envio do formulário do modal de projeto com o endpoint de criação e feedback via toast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb616bbf9083308a40861e86e78594