### PR TITLE
ajustes

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,6 +15,7 @@ export interface LoginResponse {
 export interface RefreshResponse {
   accessToken: string
   refreshToken?: string | null
+  user?: User | null
 }
 
 export async function login(payload: LoginPayload): Promise<LoginResponse> {
@@ -27,6 +28,12 @@ export async function login(payload: LoginPayload): Promise<LoginResponse> {
 export async function refreshSession(): Promise<RefreshResponse> {
   return httpClient.post<RefreshResponse>({
     url: '/auth/auth/refresh',
+  })
+}
+
+export async function getCurrentUser(): Promise<User> {
+  return httpClient.get<User>({
+    url: '/auth/me',
   })
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,88 +1,20 @@
 import type { AuthSession, User } from '../types/auth'
 
-const AUTH_USER_STORAGE_KEY = 'memo:auth-user'
-const AUTH_TOKEN_STORAGE_KEY = 'memo:auth-token'
-
 type AuthChangedEventDetail = AuthSession | null
 
-let inMemoryAccessToken: string | null | undefined
-let inMemoryUser: User | null | undefined
+let inMemoryAccessToken: string | null = null
+let inMemoryUser: User | null = null
 
 function isBrowserEnvironment(): boolean {
-  return (
-    typeof window !== 'undefined' &&
-    typeof window.localStorage !== 'undefined' &&
-    typeof window.sessionStorage !== 'undefined'
-  )
-}
-
-function readUserFromStorage(): User | null {
-  if (!isBrowserEnvironment()) {
-    return null
-  }
-
-  const rawValue = window.localStorage.getItem(AUTH_USER_STORAGE_KEY)
-  if (!rawValue) {
-    return null
-  }
-
-  try {
-    return JSON.parse(rawValue) as User
-  } catch (error) {
-    console.error('Failed to parse stored auth user', error)
-    window.localStorage.removeItem(AUTH_USER_STORAGE_KEY)
-    return null
-  }
-}
-
-function readTokenFromStorage(): string | null {
-  if (!isBrowserEnvironment()) {
-    return null
-  }
-
-  return window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ?? null
-}
-
-function persistUser(user: User | null): void {
-  if (!isBrowserEnvironment()) {
-    return
-  }
-
-  if (user) {
-    window.localStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(user))
-  } else {
-    window.localStorage.removeItem(AUTH_USER_STORAGE_KEY)
-  }
-}
-
-function persistToken(token: string | null): void {
-  if (!isBrowserEnvironment()) {
-    return
-  }
-
-  if (token) {
-    window.sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token)
-  } else {
-    window.sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
-  }
-}
-
-function getUserFromMemory(): User | null {
-  if (inMemoryUser !== undefined) {
-    return inMemoryUser
-  }
-
-  inMemoryUser = readUserFromStorage()
-  return inMemoryUser
+  return typeof window !== 'undefined' && typeof window.document !== 'undefined'
 }
 
 function getAccessTokenFromMemory(): string | null {
-  if (inMemoryAccessToken !== undefined) {
-    return inMemoryAccessToken
-  }
-
-  inMemoryAccessToken = readTokenFromStorage()
   return inMemoryAccessToken
+}
+
+function getUserFromMemory(): User | null {
+  return inMemoryUser
 }
 
 function dispatchAuthChanged(session: AuthChangedEventDetail) {
@@ -93,15 +25,9 @@ function dispatchAuthChanged(session: AuthChangedEventDetail) {
   window.dispatchEvent(new CustomEvent<AuthChangedEventDetail>('auth:changed', { detail: session }))
 }
 
-export function loadStoredUser(): User | null {
-  return getUserFromMemory()
-}
-
 export function saveAuthSession(session: AuthSession): void {
   inMemoryAccessToken = session.accessToken
   inMemoryUser = session.user
-  persistToken(session.accessToken)
-  persistUser(session.user)
   dispatchAuthChanged({ ...session })
 }
 
@@ -120,12 +46,10 @@ export function loadAuthSession(): AuthSession | null {
 export function updateAuthSession(partialSession: Partial<AuthSession>): AuthSession | null {
   if (partialSession.accessToken !== undefined) {
     inMemoryAccessToken = partialSession.accessToken ?? null
-    persistToken(inMemoryAccessToken)
   }
 
   if (partialSession.user !== undefined) {
     inMemoryUser = partialSession.user ?? null
-    persistUser(inMemoryUser)
   }
 
   const accessToken = getAccessTokenFromMemory()
@@ -146,9 +70,5 @@ export function updateAuthSession(partialSession: Partial<AuthSession>): AuthSes
 export function clearAuthSession(): void {
   inMemoryAccessToken = null
   inMemoryUser = null
-  persistToken(null)
-  persistUser(null)
   dispatchAuthChanged(null)
 }
-
-export { AUTH_USER_STORAGE_KEY }


### PR DESCRIPTION
## Summary
- stop persisting authentication data in localStorage/sessionStorage and keep it in memory only
- add an API helper to recover the current user when rebuilding a session and wire refresh responses to update the in-memory state
- adjust the auth service and axios client to rebuild sessions using backend data without exposing tokens in browser storage

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cf3c2f9afc83308ef8b23c303fe141