### PR TITLE
Atualiza lista após criação de projeto

### DIFF
--- a/src/components/sidebar/nav-modal-adicionar-projeto.tsx
+++ b/src/components/sidebar/nav-modal-adicionar-projeto.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { createProjeto } from "@/api/projeto"
+import { createProjeto, type CreateProjetoResponse } from "@/api/projeto"
 
 const projetoFormSchema = z.object({
   nome: z
@@ -51,7 +51,7 @@ export type ProjetoFormValues = z.infer<typeof projetoFormSchema>
 interface ModalAdicionarProjetoProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSubmit?: (values: ProjetoFormValues) => Promise<void> | void
+  onSubmit?: (projeto: CreateProjetoResponse) => Promise<void> | void
 }
 
 export function ModalAdicionarProjeto({ open, onOpenChange, onSubmit }: ModalAdicionarProjetoProps) {
@@ -82,7 +82,7 @@ export function ModalAdicionarProjeto({ open, onOpenChange, onSubmit }: ModalAdi
     try {
       const descricao = values.descricao?.length ? values.descricao : null
 
-      await createProjeto({
+      const projetoCriado = await createProjeto({
         nome: values.nome,
         descricao,
         organizacao: values.organizacao ?? "",
@@ -91,7 +91,7 @@ export function ModalAdicionarProjeto({ open, onOpenChange, onSubmit }: ModalAdi
 
       toast.success("Projeto criado com sucesso!")
 
-      await onSubmit?.(values)
+      await onSubmit?.(projetoCriado)
       onOpenChange(false)
       reset()
     } catch (error) {

--- a/src/components/sidebar/projeto-switcher.tsx
+++ b/src/components/sidebar/projeto-switcher.tsx
@@ -20,6 +20,7 @@ import { ModalAdicionarProjeto } from "./nav-modal-adicionar-projeto"  // Import
 import { selecionarProjeto } from "@/api/projeto"
 import { useAuth } from "@/hooks/useAuth"
 import { updateAuthSession } from "@/lib/auth"
+import type { Projeto } from "@/types/auth"
 
 type ProjetoSwitcherItem = {
   id: number
@@ -81,6 +82,35 @@ export function ProjetoSwitcher({ projetos, projetoSelecionadoId }: { projetos: 
       setProjetoAtivo(nextProjetoAtivo)
     }
   }
+
+  const handleProjetoCriado = React.useCallback(
+    (novoProjeto: Projeto) => {
+      if (!user) {
+        return
+      }
+
+      const projetosAtuais = user.projetos ?? []
+      const projetosAtualizados = [...projetosAtuais, novoProjeto]
+
+      updateAuthSession({
+        user: {
+          ...user,
+          projetos: projetosAtualizados,
+          projetoSelecionadoId: novoProjeto.id,
+        },
+      })
+
+      setProjetoAtivo({
+        id: novoProjeto.id,
+        nome: novoProjeto.nome,
+        plan: novoProjeto.cargo,
+        logo: novoProjeto.imagemUrl,
+        descricao: novoProjeto.descricao ?? "",
+        editais: novoProjeto.editais,
+      })
+    },
+    [user],
+  )
 
   if (!projetoAtivo) {
     return (
@@ -167,8 +197,9 @@ export function ProjetoSwitcher({ projetos, projetoSelecionadoId }: { projetos: 
         </DropdownMenu>
       </SidebarMenuItem>
       <ModalAdicionarProjeto
-        open={abrirModalAdicionarProjeto} 
-        onOpenChange={setAbrirModalAdicionarProjeto} 
+        open={abrirModalAdicionarProjeto}
+        onOpenChange={setAbrirModalAdicionarProjeto}
+        onSubmit={handleProjetoCriado}
       />
     </SidebarMenu>
   )

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,6 @@ import Login from '../pages/Login'
 import Dashboard from '../pages/Dashboard'
 import ProtectedRoute from './ProtectedRoute'
 import { Menu } from '../components/sidebar/app-sidebar'
-import { SidebarTrigger } from '@/components/ui/sidebar'
 
 export function AppRoutes() {
   return (


### PR DESCRIPTION
## Summary
- faz o modal de criação retornar o projeto criado para permitir atualizações externas
- atualiza o seletor de projetos para incluir o novo projeto na sessão e na seleção ativa
- remove importação não utilizada nas rotas protegidas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf701a32b8833099d06bcd00fa8dee