### PR TITLE
ajuste

### DIFF
--- a/src/api/projeto.ts
+++ b/src/api/projeto.ts
@@ -1,5 +1,5 @@
 import httpClient from "./axios"
-import type { Projeto } from "@/types/auth"
+import type { Disciplina, Projeto } from "@/types/auth"
 
 export interface CreateProjetoPayload {
   nome: string
@@ -18,6 +18,10 @@ export interface SelectProjetoResponse {
 
 export type CreateProjetoResponse = Projeto
 
+export type ProjetoDetalhado = Projeto & {
+  disciplinas: Disciplina[] | null
+}
+
 export async function createProjeto(payload: CreateProjetoPayload): Promise<CreateProjetoResponse> {
   return httpClient.post<CreateProjetoResponse>({
     url: "/projeto",
@@ -29,5 +33,11 @@ export async function selecionarProjeto(payload: SelectProjetoPayload): Promise<
   return httpClient.post<SelectProjetoResponse>({
     url: "/projeto/selecionar",
     data: payload,
+  })
+}
+
+export async function buscarProjetoPorId(projetoId: number): Promise<ProjetoDetalhado> {
+  return httpClient.get<ProjetoDetalhado>({
+    url: `/projeto/${projetoId}`,
   })
 }

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -22,16 +22,19 @@ import {
 } from "../ui/sidebar"
 import { ProjetoSwitcher } from "./projeto-switcher"
 import { Separator } from "../ui/separator"
-import { Home, MoreHorizontal } from "lucide-react"
+import { Home } from "lucide-react"
 import { NavDisciplinas } from "./nav-disciplinas"
+import type { Disciplina } from "@/types/auth"
 
 type MenuProps = React.ComponentProps<typeof Sidebar> & {
   header?: React.ReactNode
   toolbar?: React.ReactNode
+  disciplinas?: Disciplina[] | null
 }
 
-export function Menu({ children, header, toolbar, ...props }: MenuProps) {
+export function Menu({ children, header, toolbar, disciplinas, ...props }: MenuProps) {
   const { user } = useAuth();
+  const sidebarDisciplinas = disciplinas ?? user?.disciplinas ?? null;
   return (
     <SidebarProvider>
       <Sidebar collapsible="icon" {...props}>
@@ -63,7 +66,7 @@ export function Menu({ children, header, toolbar, ...props }: MenuProps) {
           </SidebarGroup>
           <NavMain items={sidebarData.navMain} />
           <NavProjects projects={sidebarData.projects} />
-          <NavDisciplinas disciplinas={user.disciplinas} />
+          <NavDisciplinas disciplinas={sidebarDisciplinas} />
         </SidebarContent>
         <SidebarFooter>
           {user && <NavUser user={user} />}

--- a/src/components/sidebar/nav-disciplinas.tsx
+++ b/src/components/sidebar/nav-disciplinas.tsx
@@ -1,18 +1,27 @@
 
 import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from "@/components/ui/sidebar"
-import { Home } from "lucide-react"
+import type { Disciplina } from "@/types/auth"
+import { BookOpen } from "lucide-react"
 
 type NavDisciplinasProps = {
-  disciplinas: Disciplina[]
+  disciplinas?: Disciplina[] | null
 }
 
 export function NavDisciplinas({ disciplinas }: NavDisciplinasProps) {
+  const lista = (disciplinas ?? []).filter(
+    (disciplina): disciplina is Disciplina => disciplina !== null && disciplina !== undefined,
+  )
+
+  if (lista.length === 0) {
+    return null
+  }
+
   return (
     <SidebarMenu>
-      {disciplinas.map((disciplina) => (
+      {lista.map(disciplina => (
         <SidebarMenuItem key={disciplina.id}>
           <SidebarMenuButton>
-            <Home />
+            <BookOpen />
             <span>{disciplina.nome}</span>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PROJETO_ID = 1 as const

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,7 +13,7 @@ import type { AuthSession, User } from '../types/auth'
 export interface AuthContextType {
   token: string | null
   user: User | null
-  login: (credentials: LoginPayload) => Promise<void>
+  login: (credentials: LoginPayload) => Promise<User>
   logout: () => Promise<void>
   isLoading: boolean
 }
@@ -83,6 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       user: data.user,
     })
     setIsLoading(false)
+    return data.user
   }, [])
 
   const logout = useCallback(async () => {

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -17,7 +17,9 @@ describe('auth session persistence', () => {
         periodoRevisao: null,
         classificacaoPerformance: null,
         foto: null,
+        disciplinas: [],
         projetos: null,
+        projetoSelecionadoId: null,
     })
 
     const createSession = (): AuthSession => ({

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Input } from "../../components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
-import { useAuth } from "../../hooks/useAuth";
-import GetStartedButton from "../../components/shsfui/button/get-started-button";
-import Comp270MessageError from "../../components/comp-270";
 import { toast } from "sonner";
+import { DEFAULT_PROJETO_ID } from "@/config/constants";
+import { useAuth } from "@/hooks/useAuth";
+import Comp270MessageError from "@/components/comp-270";
+import GetStartedButton from "@/components/shsfui/button/get-started-button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -17,8 +18,9 @@ export default function Login() {
     e.preventDefault();
     setError(null);
     try {
-      await authContext.login({ email, password });
-      navigate("/");
+      const user = await authContext.login({ email, password });
+      const projetoId = user.projetoSelecionadoId ?? DEFAULT_PROJETO_ID;
+      navigate(`/projeto/${projetoId}`, { replace: true });
     } catch (err) {
       toast.warning((err as Error).message);
     }

--- a/src/pages/Projeto/index.tsx
+++ b/src/pages/Projeto/index.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { Menu } from "@/components/sidebar/app-sidebar"
+import { DEFAULT_PROJETO_ID } from "@/config/constants"
+import { buscarProjetoPorId, type ProjetoDetalhado } from "@/api/projeto"
+import { useAuth } from "@/hooks/useAuth"
+
+function isValidProjetoId(id?: string): id is string {
+  if (!id) {
+    return false
+  }
+  const parsed = Number(id)
+  return Number.isInteger(parsed) && parsed > 0
+}
+
+export default function ProjetoPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [projeto, setProjeto] = useState<ProjetoDetalhado | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isValidProjetoId(id)) {
+      navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+      return
+    }
+
+    const numericId = Number(id)
+
+    if (user?.projetos && user.projetos.length > 0) {
+      const projetoExiste = user.projetos.some(projetoAtual => projetoAtual.id === numericId)
+      if (!projetoExiste) {
+        navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+        return
+      }
+    }
+
+    let ativo = true
+    setIsLoading(true)
+    setErro(null)
+
+    buscarProjetoPorId(numericId)
+      .then(dadosProjeto => {
+        if (!ativo) {
+          return
+        }
+        setProjeto(dadosProjeto)
+      })
+      .catch(error => {
+        if (!ativo) {
+          return
+        }
+        const mensagem = error instanceof Error ? error.message : "Não foi possível carregar o projeto"
+        if (numericId !== DEFAULT_PROJETO_ID) {
+          navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+          return
+        }
+        setErro(mensagem)
+        setProjeto(null)
+      })
+      .finally(() => {
+        if (ativo) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      ativo = false
+    }
+  }, [id, navigate, user?.projetos])
+
+  const disciplinas = projeto?.disciplinas ?? []
+  const titulo = projeto?.nome ?? "Projeto"
+  const descricao = projeto?.descricao
+
+  return (
+    <Menu header={<h1 className="text-xl font-semibold">{titulo}</h1>} disciplinas={projeto?.disciplinas ?? null}>
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <span className="text-muted-foreground">Carregando projeto...</span>
+        </div>
+      ) : erro ? (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Não foi possível carregar o projeto padrão.</h2>
+          <p className="text-sm text-muted-foreground">{erro}</p>
+        </div>
+      ) : projeto ? (
+        <div className="space-y-6">
+          <section className="space-y-2">
+            <p className="text-sm uppercase tracking-wide text-muted-foreground">Informações do Projeto</p>
+            <div className="rounded-lg border bg-card p-6 shadow-sm">
+              <h2 className="text-2xl font-semibold">{projeto.nome}</h2>
+              {descricao ? <p className="mt-2 text-muted-foreground">{descricao}</p> : null}
+              <dl className="mt-4 grid gap-4 md:grid-cols-2">
+                <div>
+                  <dt className="text-sm font-medium text-muted-foreground">Cargo</dt>
+                  <dd className="text-base font-semibold text-foreground">{projeto.cargo ?? "Não informado"}</dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-muted-foreground">Editais</dt>
+                  <dd className="text-base font-semibold text-foreground">{projeto.editais ?? "Não informado"}</dd>
+                </div>
+              </dl>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-lg font-semibold">Disciplinas</h3>
+              <p className="text-sm text-muted-foreground">
+                {disciplinas.length > 0
+                  ? "Lista de disciplinas vinculadas a este projeto."
+                  : "Nenhuma disciplina cadastrada para este projeto."}
+              </p>
+            </div>
+            {disciplinas.length > 0 ? (
+              <ul className="grid gap-4 md:grid-cols-2">
+                {disciplinas.map(disciplina => (
+                  <li key={disciplina.id} className="rounded-lg border bg-card p-4 shadow-sm">
+                    <h4 className="text-base font-semibold">{disciplina.nome}</h4>
+                    {disciplina.descricao ? (
+                      <p className="mt-2 text-sm text-muted-foreground">{disciplina.descricao}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </section>
+        </div>
+      ) : null}
+    </Menu>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,23 +1,23 @@
-import { Routes, Route } from 'react-router-dom'
-import Login from '../pages/Login'
-import Dashboard from '../pages/Dashboard'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { DEFAULT_PROJETO_ID } from '@/config/constants'
 import ProtectedRoute from './ProtectedRoute'
-import { Menu } from '../components/sidebar/app-sidebar'
+import Login from '@/pages/Login'
+import ProjetoPage from '@/pages/Projeto'
 
 export function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route
-        path="/"
+        path="/projeto/:id"
         element={
           <ProtectedRoute>
-            <Menu>
-              <Dashboard />
-            </Menu>
+            <ProjetoPage />
           </ProtectedRoute>
         }
       />
+      <Route path="/" element={<Navigate to={`/projeto/${DEFAULT_PROJETO_ID}`} replace />} />
+      <Route path="*" element={<Navigate to={`/projeto/${DEFAULT_PROJETO_ID}`} replace />} />
     </Routes>
   )
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -3,6 +3,13 @@ export interface ClassificacaoPerformance {
   regularMax: number
 }
 
+export interface Disciplina {
+  id: number
+  nome: string
+  descricao: string | null
+  cor: string | null
+}
+
 export interface Projeto {
   id: number
   nome: string
@@ -10,6 +17,7 @@ export interface Projeto {
   cargo: string | null
   editais: string | null
   imagemUrl: string | null
+  disciplinas?: Disciplina[] | null
 }
 
 export interface User {
@@ -25,6 +33,7 @@ export interface User {
   classificacaoPerformance: ClassificacaoPerformance | null
   foto: string | null
   projetos: Projeto[] | null
+  disciplinas: Disciplina[] | null
   projetoSelecionadoId: number | null
 }
 


### PR DESCRIPTION
## Summary
- add a shared default project constant and extend auth types to carry discipline data
- introduce a protected project detail page that fetches project information and redirects invalid ids to the default project
- update routing, login flow, and sidebar navigation to surface the selected project and its disciplines

## Testing
- npm run lint
- npm test *(fails: server/security/refresh-session-manager.test.ts – buildRefreshTokenClearingCookie is not a function)*
