### PR TITLE
Atualiza navegação do menu de matérias

### DIFF
--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -36,8 +36,8 @@ type MenuProps = React.ComponentProps<typeof Sidebar> & {
 
 export function Menu({ children, header, toolbar, materias, projetoSelecionado, ...props }: MenuProps) {
   const { user } = useAuth();
-  debugger
   const sidebarMaterias = projetoSelecionado?.materias ?? materias ?? user?.materias ?? null;
+  const projetoId = projetoSelecionado?.id ?? user?.projetoSelecionadoId ?? null;
   return (
     <SidebarProvider>
       <Sidebar collapsible="icon" {...props}>
@@ -67,7 +67,7 @@ export function Menu({ children, header, toolbar, materias, projetoSelecionado, 
               </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroup>
-              <NavMaterias materias={sidebarMaterias} />
+              <NavMaterias materias={sidebarMaterias} projetoId={projetoId} />
           <NavMain items={sidebarData.navMain} />
           <NavProjects projects={sidebarData.projects} />
         </SidebarContent>

--- a/src/components/sidebar/nav-materias.tsx
+++ b/src/components/sidebar/nav-materias.tsx
@@ -1,58 +1,152 @@
+import * as React from "react"
 
-import { SidebarMenuItem, SidebarMenuButton, SidebarMenuSub, SidebarMenuSubButton, SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuAction, useSidebar } from "@/components/ui/sidebar"
+import {
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  useSidebar,
+} from "@/components/ui/sidebar"
 import type { Materia } from "@/types/auth"
 import { Book, Folder, Forward, MoreHorizontal, Trash2 } from "lucide-react"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu"
+import { Link, useNavigate } from "react-router-dom"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu"
 
 type NavDisciplinasProps = {
   materias?: Materia[] | null
+  projetoId?: number | null
 }
 
-export function NavMaterias({ materias }: NavDisciplinasProps) {
-  debugger
-  const lista = (materias ?? []).filter(
-    (materia): materia is Materia => materia !== null && materia !== undefined,
+export function NavMaterias({ materias, projetoId }: NavDisciplinasProps) {
+  const lista = React.useMemo(
+    () =>
+      (materias ?? []).filter(
+        (materia): materia is Materia => materia !== null && materia !== undefined,
+      ),
+    [materias],
   )
   const { isMobile } = useSidebar()
+  const navigate = useNavigate()
+  const [materiaSelecionadaId, setMateriaSelecionadaId] = React.useState<number | null>(null)
+
+  const materiasBasePath = React.useMemo(
+    () => (projetoId != null ? `/projeto/${projetoId}/materias` : "/projeto/materias"),
+    [projetoId],
+  )
+
+  const handleVerMaterias = React.useCallback(() => {
+    navigate(materiasBasePath)
+  }, [navigate, materiasBasePath])
+
+  const handlePesquisarMaterias = React.useCallback(() => {
+    navigate(`${materiasBasePath}/buscar`)
+  }, [navigate, materiasBasePath])
+
+  const iniciarFluxoConfirmacao = React.useCallback((materiaId: number) => {
+    const confirmado = window.confirm("Tem certeza que deseja deletar esta matéria?")
+    if (confirmado) {
+      console.info("Matéria confirmada para exclusão:", materiaId)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (lista.length === 0) {
+      setMateriaSelecionadaId(null)
+      return
+    }
+
+    setMateriaSelecionadaId((valorAtual) => {
+      if (valorAtual != null && lista.some((materia) => materia.id === valorAtual)) {
+        return valorAtual
+      }
+
+      return lista[0]?.id ?? null
+    })
+  }, [lista])
+
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
       <SidebarGroupLabel>Materias</SidebarGroupLabel>
       <SidebarMenu>
-          <SidebarMenuItem >
-            <SidebarMenuButton asChild>
-              <a href={"#"}>
-                <Book />
-                <span>Materia</span>
-              </a>
-            </SidebarMenuButton>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <SidebarMenuAction showOnHover>
-                  <MoreHorizontal />
-                  <span className="sr-only">More</span>
-                </SidebarMenuAction>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                className="w-48 rounded-lg"
-                side={isMobile ? "bottom" : "right"}
-                align={isMobile ? "end" : "start"}
+        <SidebarMenuItem>
+          <SidebarMenuButton asChild>
+            <Link to={materiasBasePath}>
+              <Book />
+              <span>Materia</span>
+            </Link>
+          </SidebarMenuButton>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <SidebarMenuAction showOnHover>
+                <MoreHorizontal />
+                <span className="sr-only">More</span>
+              </SidebarMenuAction>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-48 rounded-lg"
+              side={isMobile ? "bottom" : "right"}
+              align={isMobile ? "end" : "start"}
+            >
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault()
+                  handleVerMaterias()
+                }}
               >
-                <DropdownMenuItem>
-                  <Folder className="text-muted-foreground" />
-                  <span>Ver materias</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Forward className="text-muted-foreground" />
-                  <span>Pesquisar materia</span>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem>
-                  <Trash2 className="text-muted-foreground" />
-                  <span>Deletar</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </SidebarMenuItem>
+                <Folder className="text-muted-foreground" />
+                <span>Ver materias</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault()
+                  handlePesquisarMaterias()
+                }}
+              >
+                <Forward className="text-muted-foreground" />
+                <span>Pesquisar materia</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault()
+                  if (materiaSelecionadaId != null) {
+                    iniciarFluxoConfirmacao(materiaSelecionadaId)
+                  }
+                }}
+              >
+                <Trash2 className="text-muted-foreground" />
+                <span>Deletar</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {lista.length > 0 ? (
+            <SidebarMenuSub>
+              {lista.map((materia) => (
+                <SidebarMenuSubButton
+                  asChild
+                  key={materia.id}
+                  onFocus={() => setMateriaSelecionadaId(materia.id)}
+                  onMouseEnter={() => setMateriaSelecionadaId(materia.id)}
+                >
+                  <Link to={`${materiasBasePath}/${materia.id}`}>
+                    {materia.icon ?? <Book />}
+                    <span>{materia.nome}</span>
+                  </Link>
+                </SidebarMenuSubButton>
+              ))}
+            </SidebarMenuSub>
+          ) : null}
+        </SidebarMenuItem>
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/src/pages/Projeto/index.tsx
+++ b/src/pages/Projeto/index.tsx
@@ -22,7 +22,6 @@ export default function ProjetoPage() {
   const [erro, setErro] = useState<string | null>(null)
 
   useEffect(() => {
-    debugger
     if (!isValidProjetoId(id)) {
       navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
       return
@@ -75,7 +74,6 @@ export default function ProjetoPage() {
   const disciplinas = projeto?.materias ?? []
   const titulo = projeto?.nome ?? "Projeto"
   const descricao = projeto?.descricao
-debugger
   return (
     <Menu
       header={<h1 className="text-xl font-semibold">{titulo}</h1>}


### PR DESCRIPTION
## Summary
- add projetoId prop to NavMaterias, switch to React Router links, and render submenu entries for cada matéria
- configurar ações do dropdown para navegar, pesquisar e iniciar confirmação de exclusão com o id da matéria
- propagar o projeto selecionado no Menu e remover debuggers remanescentes na página do projeto

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00e77e7f88330914ca645609dd3e0