### PR TITLE
allteracoes tabela

### DIFF
--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -24,20 +24,15 @@ import { ProjetoSwitcher } from "./projeto-switcher"
 import { Separator } from "../ui/separator"
 import { Home } from "lucide-react"
 import { NavMaterias } from "./nav-materias"
-import type { Materia } from "@/types/auth"
-import type { ProjetoDetalhado } from "@/api/projeto"
 
 type MenuProps = React.ComponentProps<typeof Sidebar> & {
   header?: React.ReactNode
   toolbar?: React.ReactNode
-  materias?: Materia[] | null
-  projetoSelecionado?: ProjetoDetalhado | null
 }
 
-export function Menu({ children, header, toolbar, materias, projetoSelecionado, ...props }: MenuProps) {
-  const { user } = useAuth();
-  debugger
-  const sidebarMaterias = projetoSelecionado?.materias ?? materias ?? user?.materias ?? null;
+export function Menu({ children, header, toolbar, ...props }: MenuProps) {
+  const { user } = useAuth()
+
   return (
     <SidebarProvider>
       <Sidebar collapsible="icon" {...props}>
@@ -65,7 +60,7 @@ export function Menu({ children, header, toolbar, materias, projetoSelecionado, 
                   <span>Home</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
-              <NavMaterias materias={sidebarMaterias} />
+              <NavMaterias />
             </SidebarMenu>
           </SidebarGroup>
           <NavMain items={sidebarData.navMain} />

--- a/src/components/sidebar/nav-materias.tsx
+++ b/src/components/sidebar/nav-materias.tsx
@@ -1,18 +1,19 @@
-
-import { SidebarMenuItem, SidebarMenuButton, SidebarMenuAction, useSidebar, SidebarGroup, SidebarMenu } from "@/components/ui/sidebar"
-import type { Materia } from "@/types/auth"
+import { SidebarMenuItem, SidebarMenuButton, SidebarMenuAction, useSidebar } from "@/components/ui/sidebar"
+import { DEFAULT_PROJETO_ID } from "@/config/constants"
 import { BookAlert, Folder, Forward, MoreHorizontal, Trash2 } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 
-type NavDisciplinasProps = {
-  materias?: Materia[] | null
-}
-
-export function NavMaterias({ materias }: NavDisciplinasProps) {
-
-  const navigate = useNavigate();
+export function NavMaterias() {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id?: string }>()
   const { isMobile } = useSidebar()
+
+  const handleVerMaterias = () => {
+    const projetoId = id ?? String(DEFAULT_PROJETO_ID)
+    navigate(`/projeto/${projetoId}/materias`)
+  }
+
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
@@ -33,7 +34,7 @@ export function NavMaterias({ materias }: NavDisciplinasProps) {
           side={isMobile ? "bottom" : "right"}
           align={isMobile ? "end" : "start"}
         >
-          <DropdownMenuItem onClick={() => navigate(`materias`)}>
+          <DropdownMenuItem onClick={handleVerMaterias}>
             <Folder className="text-muted-foreground" />
             <span>Ver Materias</span>
           </DropdownMenuItem>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -51,7 +51,6 @@ type SidebarContextProps = {
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
 function useSidebar() {
-  debugger
   const context = React.useContext(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")

--- a/src/hooks/useProjetoDetalhado.ts
+++ b/src/hooks/useProjetoDetalhado.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+
+import { buscarProjetoPorId, type ProjetoDetalhado } from "@/api/projeto"
+import { DEFAULT_PROJETO_ID } from "@/config/constants"
+import { useAuth } from "./useAuth"
+
+function isValidProjetoId(id?: string): id is string {
+  if (!id) {
+    return false
+  }
+
+  const parsed = Number(id)
+  return Number.isInteger(parsed) && parsed > 0
+}
+
+export function useProjetoDetalhado() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [projeto, setProjeto] = useState<ProjetoDetalhado | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isValidProjetoId(id)) {
+      navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+      return
+    }
+
+    const numericId = Number(id)
+
+    if (user?.projetos && user.projetos.length > 0) {
+      const projetoExiste = user.projetos.some(projetoAtual => projetoAtual.id === numericId)
+      if (!projetoExiste) {
+        navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+        return
+      }
+    }
+
+    let ativo = true
+    setIsLoading(true)
+    setErro(null)
+
+    buscarProjetoPorId(numericId)
+      .then(dadosProjeto => {
+        if (!ativo) {
+          return
+        }
+
+        setProjeto(dadosProjeto)
+      })
+      .catch(error => {
+        if (!ativo) {
+          return
+        }
+
+        const mensagem = error instanceof Error ? error.message : "Não foi possível carregar o projeto"
+        if (numericId !== DEFAULT_PROJETO_ID) {
+          navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
+          return
+        }
+
+        setErro(mensagem)
+        setProjeto(null)
+      })
+      .finally(() => {
+        if (ativo) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      ativo = false
+    }
+  }, [id, navigate, user?.projetos])
+
+  return { projeto, isLoading, erro }
+}

--- a/src/pages/Materia/index.tsx
+++ b/src/pages/Materia/index.tsx
@@ -1,8 +1,78 @@
+import { Menu } from "@/components/sidebar/app-sidebar"
+import { useProjetoDetalhado } from "@/hooks/useProjetoDetalhado"
 
 export default function Materia() {
+  const { projeto, isLoading, erro } = useProjetoDetalhado()
+  const materias = projeto?.materias ?? []
+
   return (
-    <div>
-      <h1>Materia</h1>
-    </div>
+    <Menu header={<h1 className="text-xl font-semibold">Matérias</h1>}>
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <span className="text-muted-foreground">Carregando matérias...</span>
+        </div>
+      ) : erro ? (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Não foi possível carregar as matérias.</h2>
+          <p className="text-sm text-muted-foreground">{erro}</p>
+        </div>
+      ) : materias.length > 0 ? (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Matérias vinculadas ao projeto {projeto?.nome ?? "selecionado"}.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[32rem] table-auto border-collapse text-left">
+              <thead>
+                <tr className="border-b bg-muted/50 text-sm text-muted-foreground">
+                  <th className="px-4 py-3 font-medium">Nome</th>
+                  <th className="px-4 py-3 font-medium">Descrição</th>
+                  <th className="px-4 py-3 font-medium">Cor</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {materias.map(materia => (
+                  <tr key={materia.id} className="text-sm">
+                    <td className="px-4 py-3 font-medium text-foreground">{materia.nome}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {materia.descricao ? materia.descricao : "Sem descrição"}
+                    </td>
+                    <td className="px-4 py-3">
+                      {materia.cor ? (
+                        <div className="flex items-center gap-2">
+                          <span className="h-4 w-4 rounded-full border" style={{ backgroundColor: materia.cor }} />
+                          <span className="text-xs text-muted-foreground">{materia.cor}</span>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Não definida</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${
+                          materia.isActive
+                            ? "bg-emerald-100 text-emerald-700"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {materia.isActive ? "Ativa" : "Inativa"}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card p-6 text-center shadow-sm">
+          <h2 className="text-lg font-semibold">Nenhuma matéria cadastrada</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Cadastre uma nova matéria para visualizar aqui.
+          </p>
+        </div>
+      )}
+    </Menu>
   )
 }

--- a/src/pages/Projeto/index.tsx
+++ b/src/pages/Projeto/index.tsx
@@ -1,87 +1,15 @@
-import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router-dom"
 import { Menu } from "@/components/sidebar/app-sidebar"
-import { DEFAULT_PROJETO_ID } from "@/config/constants"
-import { buscarProjetoPorId, type ProjetoDetalhado } from "@/api/projeto"
-import { useAuth } from "@/hooks/useAuth"
-
-function isValidProjetoId(id?: string): id is string {
-  if (!id) {
-    return false
-  }
-  const parsed = Number(id)
-  return Number.isInteger(parsed) && parsed > 0
-}
+import { useProjetoDetalhado } from "@/hooks/useProjetoDetalhado"
 
 export default function ProjetoPage() {
-  const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const { user } = useAuth()
-  const [projeto, setProjeto] = useState<ProjetoDetalhado | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [erro, setErro] = useState<string | null>(null)
-
-  useEffect(() => {
-    debugger
-    if (!isValidProjetoId(id)) {
-      navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
-      return
-    }
-
-    const numericId = Number(id)
-
-    if (user?.projetos && user.projetos.length > 0) {
-      const projetoExiste = user.projetos.some(projetoAtual => projetoAtual.id === numericId)
-      if (!projetoExiste) {
-        navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
-        return
-      }
-    }
-
-    let ativo = true
-    setIsLoading(true)
-    setErro(null)
-
-    buscarProjetoPorId(numericId)
-      .then(dadosProjeto => {
-        if (!ativo) {
-          return
-        }
-        setProjeto(dadosProjeto)
-      })
-      .catch(error => {
-        if (!ativo) {
-          return
-        }
-        const mensagem = error instanceof Error ? error.message : "Não foi possível carregar o projeto"
-        if (numericId !== DEFAULT_PROJETO_ID) {
-          navigate(`/projeto/${DEFAULT_PROJETO_ID}`, { replace: true })
-          return
-        }
-        setErro(mensagem)
-        setProjeto(null)
-      })
-      .finally(() => {
-        if (ativo) {
-          setIsLoading(false)
-        }
-      })
-
-    return () => {
-      ativo = false
-    }
-  }, [id, navigate, user?.projetos])
+  const { projeto, isLoading, erro } = useProjetoDetalhado()
 
   const disciplinas = projeto?.materias ?? []
   const titulo = projeto?.nome ?? "Projeto"
   const descricao = projeto?.descricao
-debugger
+
   return (
-    <Menu
-      header={<h1 className="text-xl font-semibold">{titulo}</h1>}
-      materias={projeto?.materias ?? null}
-      projetoSelecionado={projeto}
-    >
+    <Menu header={<h1 className="text-xl font-semibold">{titulo}</h1>}>
       {isLoading ? (
         <div className="flex flex-1 items-center justify-center">
           <span className="text-muted-foreground">Carregando projeto...</span>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_PROJETO_ID } from '@/config/constants'
 import ProtectedRoute from './ProtectedRoute'
 import Login from '@/pages/Login'
 import ProjetoPage from '@/pages/Projeto'
-import Materia from '@/pages/Materia' // Importando o componente Materia
+import Materia from '@/pages/Materia'
 
 export function AppRoutes() {
   return (
@@ -17,7 +17,14 @@ export function AppRoutes() {
           </ProtectedRoute>
         }
       />
-      <Route path="/materias" element={<Materia />} /> {/* Rota independente para Materia */}
+      <Route
+        path="/projeto/:id/materias"
+        element={
+          <ProtectedRoute>
+            <Materia />
+          </ProtectedRoute>
+        }
+      />
       <Route path="/" element={<Navigate to={`/projeto/${DEFAULT_PROJETO_ID}`} replace />} />
       <Route path="*" element={<Navigate to={`/projeto/${DEFAULT_PROJETO_ID}`} replace />} />
     </Routes>


### PR DESCRIPTION
## Summary
- extract project loading logic to a shared hook for project-related pages
- add the /projeto/:id/materias route with a table view for project subjects
- update sidebar navigation to link directly to the materias view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ea5b7eec83309804ffb810ffd26a