### PR TITLE
ajuste colorPicker

### DIFF
--- a/src/components/color-picker.tsx
+++ b/src/components/color-picker.tsx
@@ -55,6 +55,7 @@ export const ColorPicker = ({
   defaultValue = '#000000',
   onChange,
   className,
+  children,
   ...props
 }: ColorPickerProps) => {
   const selectedColor = Color(value || defaultValue); // Garantir que sempre haja um valor válido
@@ -111,7 +112,9 @@ export const ColorPicker = ({
       <div
         className={cn('flex size-full flex-col gap-4', className)}
         {...props}
-      />
+      >
+        {children}
+      </div>
     </ColorPickerContext.Provider>
   );
 };
@@ -283,7 +286,10 @@ export const ColorPickerOutput = ({
   const { mode, setMode } = useColorPicker();
   return (
     <Select onValueChange={setMode} value={mode}>
-      <SelectTrigger className="h-8 w-20 shrink-0 text-xs" {...props}>
+      <SelectTrigger
+        className={cn('h-8 w-20 shrink-0 text-xs', className)}
+        {...props}
+      >
         <SelectValue placeholder="Mode" />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/sidebar/nav-modal-adicionar-materia.tsx
+++ b/src/components/sidebar/nav-modal-adicionar-materia.tsx
@@ -9,7 +9,16 @@ import z from "zod";
 import { useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useCallback, useState } from "react";
-import { ColorPicker } from "@/components/color-picker"; // Importando o ColorPicker
+import {
+    ColorPicker,
+    ColorPickerAlpha,
+    ColorPickerFormat,
+    ColorPickerHue,
+    ColorPickerOutput,
+    ColorPickerSelection,
+} from "@/components/color-picker";
+
+const DEFAULT_COLOR = "rgba(0,0,0,1)";
 
 const materiaFormSchema = z.object({
     nome: z.string().min(1, "O nome é obrigatório"),
@@ -21,24 +30,34 @@ export type MateriaFormValues = z.infer<typeof materiaFormSchema>;
 export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
     const { projetoId } = useParams<{ projetoId?: string }>();
     const navigate = useNavigate();
-    const [selectedColor, setSelectedColor] = useState<string>("rgba(0,0,0,1)"); // Valor inicial válido
     const [isColorPickerOpen, setIsColorPickerOpen] = useState(false); // Estado para controlar a visibilidade do ColorPicker
+
+    const form = useForm<MateriaFormValues>({
+        resolver: zodResolver(materiaFormSchema),
+        defaultValues: {
+            nome: "",
+            cor: DEFAULT_COLOR, // Valor padrão para a cor
+        },
+    });
+
+    const { control, reset, formState } = form;
+
+    const handleOpenChange = useCallback(
+        (nextOpen: boolean) => {
+            if (!nextOpen) {
+                reset({ nome: "", cor: DEFAULT_COLOR });
+                setIsColorPickerOpen(false);
+            }
+            onOpenChange(nextOpen);
+        },
+        [onOpenChange, reset],
+    );
 
     if (!projetoId) {
         console.error("projetoId não encontrado!");
         toast.error("Projeto não encontrado. Verifique a URL.");
         return null;
     }
-
-    const form = useForm<MateriaFormValues>({
-        resolver: zodResolver(materiaFormSchema),
-        defaultValues: {
-            nome: "",
-            cor: selectedColor, // Valor padrão para a cor
-        },
-    });
-
-    const { control, handleSubmit: submit, reset, formState } = form;
 
     const handleSubmit = form.handleSubmit(async (values) => {
         try {
@@ -61,16 +80,6 @@ export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; o
             toast.error(message);
         }
     });
-
-    const handleOpenChange = useCallback(
-        (nextOpen: boolean) => {
-            if (!nextOpen) {
-                reset();
-            }
-            onOpenChange(nextOpen);
-        },
-        [onOpenChange, reset],
-    );
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -100,37 +109,62 @@ export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; o
                             <FormField
                                 control={control}
                                 name="cor"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Cor da matéria</FormLabel>
-                                        <FormControl>
-                                            <div className="flex items-center gap-4">
-                                                {/* Botão para abrir o ColorPicker */}
-                                                <Button
-                                                    type="button"
-                                                    className="w-10 h-10 p-0 border"
-                                                    style={{ backgroundColor: selectedColor }}
-                                                    onClick={() => setIsColorPickerOpen(!isColorPickerOpen)}
-                                                />
-                                                <span>{selectedColor}</span>
-                                            </div>
-                                            {/* ColorPicker */}
-                                            {isColorPickerOpen && (
-                                                <div className="mt-4">
-                                                    <ColorPicker
-                                                        value={selectedColor}
-                                                        onChange={(color) => {
-                                                            const formattedColor = `rgba(${color.join(",")})`; // Formatando a cor corretamente
-                                                            setSelectedColor(formattedColor);
-                                                            field.onChange(formattedColor); // Atualizando o valor do campo
-                                                        }}
-                                                    />
+                                render={({ field }) => {
+                                    const currentColor = (field.value as string | undefined) ?? DEFAULT_COLOR;
+                                    return (
+                                        <FormItem>
+                                            <FormLabel>Cor da matéria</FormLabel>
+                                            <FormControl>
+                                                <div className="space-y-4">
+                                                    <div className="flex items-center gap-4">
+                                                        <Button
+                                                            type="button"
+                                                            className="h-10 w-10 p-0"
+                                                            style={{ backgroundColor: currentColor }}
+                                                            onClick={() => setIsColorPickerOpen((open) => !open)}
+                                                            aria-label="Selecionar cor da matéria"
+                                                        />
+                                                        <span className="font-mono text-sm text-muted-foreground">
+                                                            {currentColor}
+                                                        </span>
+                                                    </div>
+                                                    {isColorPickerOpen && (
+                                                        <div className="space-y-4 rounded-md border border-border p-4">
+                                                            <ColorPicker
+                                                                value={currentColor}
+                                                                onChange={(color) => {
+                                                                    const [r = 0, g = 0, b = 0, a = 1] = color as [
+                                                                        number,
+                                                                        number,
+                                                                        number,
+                                                                        number?,
+                                                                    ];
+                                                                    const alpha = Math.round(((a ?? 1) * 100)) / 100;
+                                                                    const formattedColor = `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha})`;
+                                                                    field.onChange(formattedColor);
+                                                                }}
+                                                                className="gap-4"
+                                                            >
+                                                                <div className="relative h-48 w-full overflow-hidden rounded-md border border-border">
+                                                                    <ColorPickerSelection className="h-full w-full" />
+                                                                </div>
+                                                                <div className="space-y-3">
+                                                                    <ColorPickerHue className="h-4 w-full" />
+                                                                    <ColorPickerAlpha className="h-4 w-full" />
+                                                                </div>
+                                                                <div className="flex items-center gap-2">
+                                                                    <ColorPickerOutput className="w-24" />
+                                                                    <ColorPickerFormat className="flex-1" />
+                                                                </div>
+                                                            </ColorPicker>
+                                                        </div>
+                                                    )}
                                                 </div>
-                                            )}
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    );
+                                }}
                             />
                         </div>
                         <DialogFooter>

--- a/src/components/ui/shadcn-io/color-picker/index.tsx
+++ b/src/components/ui/shadcn-io/color-picker/index.tsx
@@ -320,7 +320,10 @@ export const ColorPickerOutput = ({
 
   return (
     <Select onValueChange={setMode} value={mode}>
-      <SelectTrigger className="h-8 w-20 shrink-0 text-xs" {...props}>
+      <SelectTrigger
+        className={cn('h-8 w-20 shrink-0 text-xs', className)}
+        {...props}
+      >
         <SelectValue placeholder="Mode" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## Summary
- render the color picker selection, sliders, and format outputs inside the add subject modal
- allow the shared color picker provider to render its children content
- propagate optional trigger styling through the shadcn color picker output helper

## Testing
- npm run lint *(fails: existing `react-refresh/only-export-components` errors in shared UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a8c149988330b091a31f630d7dae