### PR TITLE
ajustes

### DIFF
--- a/src/components/color-picker.tsx
+++ b/src/components/color-picker.tsx
@@ -23,17 +23,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+type ColorPickerMode = 'hex' | 'rgb' | 'css' | 'hsl';
+
 interface ColorPickerContextValue {
   hue: number;
   saturation: number;
   lightness: number;
   alpha: number;
-  mode: string;
+  mode: ColorPickerMode;
   setHue: (hue: number) => void;
   setSaturation: (saturation: number) => void;
   setLightness: (lightness: number) => void;
   setAlpha: (alpha: number) => void;
-  setMode: (mode: string) => void;
+  setMode: (mode: ColorPickerMode) => void;
 }
 const ColorPickerContext = createContext<ColorPickerContextValue | undefined>(
   undefined
@@ -48,50 +50,129 @@ export const useColorPicker = () => {
 export type ColorPickerProps = HTMLAttributes<HTMLDivElement> & {
   value?: Parameters<typeof Color>[0];
   defaultValue?: Parameters<typeof Color>[0];
-  onChange?: (value: Parameters<typeof Color.rgb>[0]) => void;
+  onChange?: (value: string) => void;
 };
 export const ColorPicker = ({
   value,
   defaultValue = '#000000',
   onChange,
   className,
+  children,
   ...props
 }: ColorPickerProps) => {
-  const selectedColor = Color(value || defaultValue); // Garantir que sempre haja um valor válido
-  const defaultColor = Color(defaultValue);
+  const fallbackColor = useMemo(() => {
+    try {
+      return Color(defaultValue);
+    } catch (error) {
+      console.error('Invalid default color provided to ColorPicker:', error);
+      return Color('#000000');
+    }
+  }, [defaultValue]);
+
+  const selectedColor = useMemo(() => {
+    try {
+      return value ? Color(value) : fallbackColor;
+    } catch (error) {
+      console.error('Invalid color value provided to ColorPicker:', error);
+      return fallbackColor;
+    }
+  }, [value, fallbackColor]);
   const [hue, setHue] = useState(
-    selectedColor.hue() || defaultColor.hue() || 0
+    selectedColor.hue() || fallbackColor.hue() || 0
   );
   const [saturation, setSaturation] = useState(
-    selectedColor.saturationl() || defaultColor.saturationl() || 100
+    selectedColor.saturationl() || fallbackColor.saturationl() || 100
   );
   const [lightness, setLightness] = useState(
-    selectedColor.lightness() || defaultColor.lightness() || 50
+    selectedColor.lightness() || fallbackColor.lightness() || 50
   );
   const [alpha, setAlpha] = useState(
-    (selectedColor.alpha() || defaultColor.alpha()) * 100 || 100 // Garantir que alpha seja sempre um número válido
+    (selectedColor.alpha() || fallbackColor.alpha()) * 100 || 100
   );
-  const [mode, setMode] = useState('hex');
+  const inferMode = useCallback((input?: Parameters<typeof Color>[0]) => {
+    if (!input || typeof input !== 'string') {
+      return 'hex';
+    }
+    if (input.startsWith('rgb')) return 'rgb';
+    if (input.startsWith('hsl')) return 'hsl';
+    if (input.startsWith('#')) return 'hex';
+    return 'css';
+  }, []);
+
+  const [mode, setModeState] = useState<ColorPickerMode>(() => inferMode(value));
+  const modeDirtyRef = useRef(false);
+  const setMode = useCallback(
+    (nextMode: ColorPickerMode) => {
+      modeDirtyRef.current = true;
+      setModeState(nextMode);
+    },
+    []
+  );
+
+  const suppressChangeRef = useRef(false);
+  const lastEmittedValueRef = useRef<string | null>(null);
 
   // Update color when controlled value changes
   useEffect(() => {
-    if (value) {
-      const color = Color.rgb(value).rgb().object();
-      setHue(color.r || 0);
-      setSaturation(color.g || 0);
-      setLightness(color.b || 0);
-      setAlpha((color.a || 1) * 100); // Garantir que alpha seja sempre um número válido
+    if (!value) {
+      return;
     }
-  }, [value]);
+
+    try {
+      const color = Color(value);
+      const [nextHue, nextSaturation, nextLightness] = color
+        .hsl()
+        .array();
+
+      setHue(nextHue || 0);
+      setSaturation(nextSaturation || 0);
+      setLightness(nextLightness || 0);
+      setAlpha((color.alpha() || 1) * 100);
+      suppressChangeRef.current = true;
+      lastEmittedValueRef.current =
+        typeof value === 'string' ? value : color.string();
+      if (!modeDirtyRef.current) {
+        setModeState(inferMode(value));
+      }
+    } catch (error) {
+      console.error('Failed to parse color value in ColorPicker:', error);
+    }
+  }, [value, inferMode]);
 
   // Notify parent of changes
   useEffect(() => {
     if (onChange) {
+      if (suppressChangeRef.current) {
+        suppressChangeRef.current = false;
+        return;
+      }
       const color = Color.hsl(hue, saturation, lightness).alpha(alpha / 100);
-      const rgba = color.rgb().array();
-      onChange([rgba[0], rgba[1], rgba[2], alpha / 100]);
+      let formatted = color.string();
+
+      switch (mode) {
+        case 'hex':
+          formatted = alpha === 100 ? color.hex() : color.hexa();
+          break;
+        case 'rgb':
+          formatted = color.rgb().string();
+          break;
+        case 'hsl':
+          formatted = color.hsl().string();
+          break;
+        case 'css':
+        default:
+          formatted = color.string();
+          break;
+      }
+
+      if (lastEmittedValueRef.current === formatted) {
+        return;
+      }
+
+      lastEmittedValueRef.current = formatted;
+      onChange(formatted);
     }
-  }, [hue, saturation, lightness, alpha, onChange]);
+  }, [hue, saturation, lightness, alpha, mode, onChange]);
 
   return (
     <ColorPickerContext.Provider
@@ -111,7 +192,9 @@ export const ColorPicker = ({
       <div
         className={cn('flex size-full flex-col gap-4', className)}
         {...props}
-      />
+      >
+        {children}
+      </div>
     </ColorPickerContext.Provider>
   );
 };
@@ -122,7 +205,13 @@ export const ColorPickerSelection = memo(
     const [isDragging, setIsDragging] = useState(false);
     const [positionX, setPositionX] = useState(0);
     const [positionY, setPositionY] = useState(0);
-    const { hue, setSaturation, setLightness } = useColorPicker();
+    const {
+      hue,
+      saturation,
+      lightness,
+      setSaturation,
+      setLightness,
+    } = useColorPicker();
     const backgroundGradient = useMemo(() => {
       return `linear-gradient(0deg, rgba(0,0,0,1), rgba(0,0,0,0)),
             linear-gradient(90deg, rgba(255,255,255,1), rgba(255,255,255,0)),
@@ -145,12 +234,18 @@ export const ColorPickerSelection = memo(
         setPositionX(x);
         setPositionY(y);
         setSaturation(x * 100);
-        const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
-        const lightness = topLightness * (1 - y);
-        setLightness(lightness);
+        setLightness(100 - y * 100);
       },
       [isDragging, setSaturation, setLightness]
     );
+    useEffect(() => {
+      if (isDragging) {
+        return;
+      }
+
+      setPositionX(saturation / 100);
+      setPositionY(1 - lightness / 100);
+    }, [isDragging, saturation, lightness]);
     useEffect(() => {
       const handlePointerUp = () => setIsDragging(false);
       if (isDragging) {
@@ -275,15 +370,18 @@ export const ColorPickerEyeDropper = ({
   );
 };
 export type ColorPickerOutputProps = ComponentProps<typeof SelectTrigger>;
-const formats = ['hex', 'rgb', 'css', 'hsl'];
+const formats: ColorPickerMode[] = ['hex', 'rgb', 'css', 'hsl'];
 export const ColorPickerOutput = ({
   className,
   ...props
 }: ColorPickerOutputProps) => {
   const { mode, setMode } = useColorPicker();
   return (
-    <Select onValueChange={setMode} value={mode}>
-      <SelectTrigger className="h-8 w-20 shrink-0 text-xs" {...props}>
+    <Select onValueChange={(value) => setMode(value as ColorPickerMode)} value={mode}>
+      <SelectTrigger
+        className={cn('h-8 w-20 shrink-0 text-xs', className)}
+        {...props}
+      >
         <SelectValue placeholder="Mode" />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/sidebar/nav-modal-adicionar-materia.tsx
+++ b/src/components/sidebar/nav-modal-adicionar-materia.tsx
@@ -1,3 +1,4 @@
+import Color from "color";
 import { toast } from "sonner";
 import { Button } from "../ui/button";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../ui/dialog";
@@ -9,7 +10,16 @@ import z from "zod";
 import { useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useCallback, useState } from "react";
-import { ColorPicker } from "@/components/color-picker"; // Importando o ColorPicker
+import {
+    ColorPicker,
+    ColorPickerAlpha,
+    ColorPickerFormat,
+    ColorPickerHue,
+    ColorPickerOutput,
+    ColorPickerSelection,
+} from "@/components/color-picker";
+
+const DEFAULT_COLOR = "#000000";
 
 const materiaFormSchema = z.object({
     nome: z.string().min(1, "O nome é obrigatório"),
@@ -21,24 +31,34 @@ export type MateriaFormValues = z.infer<typeof materiaFormSchema>;
 export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
     const { projetoId } = useParams<{ projetoId?: string }>();
     const navigate = useNavigate();
-    const [selectedColor, setSelectedColor] = useState<string>("rgba(0,0,0,1)"); // Valor inicial válido
     const [isColorPickerOpen, setIsColorPickerOpen] = useState(false); // Estado para controlar a visibilidade do ColorPicker
+
+    const form = useForm<MateriaFormValues>({
+        resolver: zodResolver(materiaFormSchema),
+        defaultValues: {
+            nome: "",
+            cor: DEFAULT_COLOR, // Valor padrão para a cor
+        },
+    });
+
+    const { control, reset, formState } = form;
+
+    const handleOpenChange = useCallback(
+        (nextOpen: boolean) => {
+            if (!nextOpen) {
+                reset({ nome: "", cor: DEFAULT_COLOR });
+                setIsColorPickerOpen(false);
+            }
+            onOpenChange(nextOpen);
+        },
+        [onOpenChange, reset],
+    );
 
     if (!projetoId) {
         console.error("projetoId não encontrado!");
         toast.error("Projeto não encontrado. Verifique a URL.");
         return null;
     }
-
-    const form = useForm<MateriaFormValues>({
-        resolver: zodResolver(materiaFormSchema),
-        defaultValues: {
-            nome: "",
-            cor: selectedColor, // Valor padrão para a cor
-        },
-    });
-
-    const { control, handleSubmit: submit, reset, formState } = form;
 
     const handleSubmit = form.handleSubmit(async (values) => {
         try {
@@ -61,16 +81,6 @@ export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; o
             toast.error(message);
         }
     });
-
-    const handleOpenChange = useCallback(
-        (nextOpen: boolean) => {
-            if (!nextOpen) {
-                reset();
-            }
-            onOpenChange(nextOpen);
-        },
-        [onOpenChange, reset],
-    );
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -100,37 +110,67 @@ export function ModalAdicionarMateria({ open, onOpenChange }: { open: boolean; o
                             <FormField
                                 control={control}
                                 name="cor"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Cor da matéria</FormLabel>
-                                        <FormControl>
-                                            <div className="flex items-center gap-4">
-                                                {/* Botão para abrir o ColorPicker */}
-                                                <Button
-                                                    type="button"
-                                                    className="w-10 h-10 p-0 border"
-                                                    style={{ backgroundColor: selectedColor }}
-                                                    onClick={() => setIsColorPickerOpen(!isColorPickerOpen)}
-                                                />
-                                                <span>{selectedColor}</span>
-                                            </div>
-                                            {/* ColorPicker */}
-                                            {isColorPickerOpen && (
-                                                <div className="mt-4">
-                                                    <ColorPicker
-                                                        value={selectedColor}
-                                                        onChange={(color) => {
-                                                            const formattedColor = `rgba(${color.join(",")})`; // Formatando a cor corretamente
-                                                            setSelectedColor(formattedColor);
-                                                            field.onChange(formattedColor); // Atualizando o valor do campo
-                                                        }}
-                                                    />
+                                render={({ field }) => {
+                                    const currentColor = (field.value as string | undefined) ?? DEFAULT_COLOR;
+                                    return (
+                                        <FormItem>
+                                            <FormLabel>Cor da matéria</FormLabel>
+                                            <FormControl>
+                                                <div className="space-y-4">
+                                                    <div className="flex items-center gap-4">
+                                                        <Button
+                                                            type="button"
+                                                            className="h-10 w-10 p-0"
+                                                            style={{ backgroundColor: currentColor }}
+                                                            onClick={() => setIsColorPickerOpen((open) => !open)}
+                                                            aria-label="Selecionar cor da matéria"
+                                                        />
+                                                        <span className="font-mono text-sm text-muted-foreground">
+                                                            {currentColor}
+                                                        </span>
+                                                    </div>
+                                                    {isColorPickerOpen && (
+                                                        <div className="space-y-4 rounded-md border border-border p-4">
+                                                            <ColorPicker
+                                                                value={currentColor}
+                                                                onChange={(nextColor) => {
+                                                                    try {
+                                                                        const color = Color(nextColor);
+                                                                        const normalizedColor =
+                                                                            color.alpha() < 1
+                                                                                ? color.hexa()
+                                                                                : color.hex();
+                                                                        field.onChange(normalizedColor);
+                                                                    } catch (error) {
+                                                                        console.error(
+                                                                            "Falha ao converter a cor para hexadecimal:",
+                                                                            error,
+                                                                        );
+                                                                        field.onChange(nextColor);
+                                                                    }
+                                                                }}
+                                                                className="gap-4"
+                                                            >
+                                                                <div className="relative h-48 w-full overflow-hidden rounded-md border border-border">
+                                                                    <ColorPickerSelection className="h-full w-full" />
+                                                                </div>
+                                                                <div className="space-y-3">
+                                                                    <ColorPickerHue className="h-4 w-full" />
+                                                                    <ColorPickerAlpha className="h-4 w-full" />
+                                                                </div>
+                                                                <div className="flex items-center gap-2">
+                                                                    <ColorPickerOutput className="w-24" />
+                                                                    <ColorPickerFormat className="flex-1" />
+                                                                </div>
+                                                            </ColorPicker>
+                                                        </div>
+                                                    )}
                                                 </div>
-                                            )}
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    );
+                                }}
                             />
                         </div>
                         <DialogFooter>

--- a/src/components/ui/shadcn-io/color-picker/index.tsx
+++ b/src/components/ui/shadcn-io/color-picker/index.tsx
@@ -320,7 +320,10 @@ export const ColorPickerOutput = ({
 
   return (
     <Select onValueChange={setMode} value={mode}>
-      <SelectTrigger className="h-8 w-20 shrink-0 text-xs" {...props}>
+      <SelectTrigger
+        className={cn('h-8 w-20 shrink-0 text-xs', className)}
+        {...props}
+      >
         <SelectValue placeholder="Mode" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## Summary
- prevent the color picker from resetting the display mode when the controlled value changes unless the user hasn't chosen one yet
- default the subject modal color to hex and normalize emitted values to hex/hexa before persisting them

## Testing
- npm run lint *(fails: existing `react-refresh/only-export-components` rule violations in shared UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a8c149988330b091a31f630d7dae